### PR TITLE
Support for alternative http useragent and headers

### DIFF
--- a/org.archicontribs.modelrepository/src/org/archicontribs/modelrepository/ModelRepositoryPlugin.java
+++ b/org.archicontribs.modelrepository/src/org/archicontribs/modelrepository/ModelRepositoryPlugin.java
@@ -21,6 +21,7 @@ import org.archicontribs.modelrepository.preferences.IPreferenceConstants;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jgit.transport.UserAgent;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -44,6 +45,9 @@ public class ModelRepositoryPlugin extends AbstractUIPlugin implements PropertyC
      */
     public static ModelRepositoryPlugin INSTANCE;
     
+    public static String ENV_VAR_USERAGENT = "ARCHI_GIT_USERAGENT";
+    public static String ENV_VAR_ADDITIONALHEADER = "ARCHI_GIT_ADDITIONALHEADER";
+    
     public ModelRepositoryPlugin() {
         INSTANCE = this;
     }
@@ -52,7 +56,10 @@ public class ModelRepositoryPlugin extends AbstractUIPlugin implements PropertyC
     public void start(BundleContext context) throws Exception {
         super.start(context);
         IEditorModelManager.INSTANCE.addPropertyChangeListener(this);
-        
+        //override git useragent if specified in system property
+        if (System.getenv(ENV_VAR_USERAGENT) != null && !System.getenv(ENV_VAR_USERAGENT).isEmpty()) {
+        	UserAgent.set(System.getenv(ENV_VAR_USERAGENT));
+        }
         // Set this first
         ProxyAuthenticator.init();
     }


### PR DESCRIPTION
Some environments (especially in larger enterprise) might require additional authentication credentials via http headers or cookies. In my case one needs to send an additional cookie for each request which is obtained via multi-factor-auth. I have seen similar cases for others. With git this is normally easy to achieve using the http.extraheader config option. I added a small hook to be able to set this via system environment variable. I also initially thought about adding this as part of the preferences or authentication dialog but since this is kind of special feature and the MFA cookie might change every day it is probable the easiest way to go via env variables.
IN addition I also added a similar feature for the http user agent since our reverse proxy configuration does not seem to allow JGit user agents.